### PR TITLE
Don't deserialize empty bodies from 204 responses

### DIFF
--- a/dist/ember-restless.js
+++ b/dist/ember-restless.js
@@ -456,7 +456,9 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
         saveRequest = this.request(record, { type: method, data: record.serialize() });
 
     saveRequest.done(function(data){
-      record.deserialize(data);
+      if (data) {    // 204 No Content responses send no body
+        record.deserialize(data);
+      }
       record.clearErrors();
       record.set('isDirty', false);
       record._triggerEvent(isNew ? 'didCreate' : 'didUpdate');

--- a/src/adapters/rest_adapter.js
+++ b/src/adapters/rest_adapter.js
@@ -81,7 +81,9 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
         saveRequest = this.request(record, { type: method, data: record.serialize() });
 
     saveRequest.done(function(data){
-      record.deserialize(data);
+      if (data) {    // 204 No Content responses send no body
+        record.deserialize(data);
+      }
       record.clearErrors();
       record.set('isDirty', false);
       record._triggerEvent(isNew ? 'didCreate' : 'didUpdate');


### PR DESCRIPTION
So that saves don't blow up when APIs return 204 sucess responses with no body
