### PR TITLE
load and loadMany for sideloaded JSON

### DIFF
--- a/dist/ember-restless.js
+++ b/dist/ember-restless.js
@@ -855,6 +855,30 @@ RESTless.Model.reopenClass({
    */
   findAll: function(params) {
     return RESTless.get('client.adapter').findAll(this, params);
+  },
+
+  /*
+   * load: Create model directly from data representation.
+   */
+  load: function(data) {
+    var result = this.create();
+
+    result.deserialize(data);
+    result.set('isLoaded', true);
+
+    return result;
+  },
+
+  /*
+   * loadMany: Create collection of records directly from data representation.
+   */
+  loadMany: function(data) {
+    var result = RESTless.RecordArray.createWithContent({ type: this.toString() });
+
+    result.deserializeMany(data);
+    result.set('isLoaded', true);
+
+    return result;
   }
 });
 

--- a/src/model.js
+++ b/src/model.js
@@ -197,5 +197,29 @@ RESTless.Model.reopenClass({
    */
   findAll: function(params) {
     return RESTless.get('client.adapter').findAll(this, params);
+  },
+
+  /*
+   * load: Create model directly from data representation.
+   */
+  load: function(data) {
+    var result = this.create();
+
+    result.deserialize(data);
+    result.set('isLoaded', true);
+
+    return result;
+  },
+
+  /*
+   * loadMany: Create collection of records directly from data representation.
+   */
+  loadMany: function(data) {
+    var result = RESTless.RecordArray.createWithContent({ type: this.toString() });
+
+    result.deserializeMany(data);
+    result.set('isLoaded', true);
+
+    return result;
   }
 });


### PR DESCRIPTION
Useful for loading models from JSON bootstrapped into a page or sent down through websockets, etc.

Similar to load and loadMany in ember-data's store.
