### PR TITLE
Computed properties for fields

### DIFF
--- a/src/adapters/rest_adapter.js
+++ b/src/adapters/rest_adapter.js
@@ -133,7 +133,7 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
   },
 
   findAll: function(model, params) {
-    var resourceInstance = model.create(),
+    var resourceInstance = model.create({ isNew: false }),
         result = RESTless.RecordArray.createWithContent({ type: model.toString() }),
         findRequest = this.request(resourceInstance, { type: 'GET', data: params });
 
@@ -152,7 +152,7 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
   },
 
   findByKey: function(model, key) {
-    var result = model.create(),
+    var result = model.create({ isNew: false }),
         findRequest = this.request(result, { type: 'GET' }, key);
 
     findRequest.done(function(data){

--- a/src/array.js
+++ b/src/array.js
@@ -31,14 +31,16 @@ RESTless.RecordArray = Ember.ArrayProxy.extend( RESTless.State, {
   },
 
   /*
-   * _onContentChange: (private) observes when items in the array are changed.
-   * Marks the RecordArray as dirty if loaded.
+   * replaceContent: Changes array contents. Overriden to mark RecordArray as
+   * dirty if loaded.
    */
-  _onContentChange: function() {
-    if(this.get('isLoaded')) {
+  replaceContent: function(idx, amt, objects) {
+    get(this, 'content').replace(idx, amt, objects);
+    if (this.get('isLoaded')) {
       this.set('isDirty', true);
     }
-  }.observes('@each'),
+  },
+
   /*
    * _onItemDirtyChange: (private) observes when items become dirty
    */

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -1,32 +1,59 @@
-/*
- * RESTless._Attribute (private)
- * Stores metadata about model property types
- */
-RESTless._Attribute = Ember.ObjectProxy.extend({
-  type: null,
+var attributeDefaults = {
   readOnly: false,
   belongsTo: false,
   hasMany: false,
+  isAttribute: false,
   isRelationship: false
-});
+};
 
-/*
- * Public attribute interfaces to define model properties
- */
+function makeComputedAttribute(type, opts) {
+  opts = $.extend({}, attributeDefaults, { type: type }, opts);
+
+  return Ember.computed(function(key, value) {
+    var data = this.get('_data');
+
+    if (arguments.length === 1) {       // Getter
+      value = data[key];
+
+      if (value === undefined) {        // Default values
+        if (typeof opts.defaultValue === 'function') {
+          value = opts.defaultValue();
+        } else {
+          value = opts.defaultValue;
+        }
+        data[key] = value;
+      }
+    } else if (value !== data[key]) {   // Setter
+      data[key] = value;
+      if (!opts.readOnly) {
+        this._onPropertyChange(key);
+      }
+    }
+
+    return value;
+  }).property('_data').meta(opts);
+}
+
 // Standard property
 RESTless.attr = function(type, opts) {
-  opts = $.extend({ type: type }, opts);
-  return RESTless._Attribute.create(opts);
+  opts = $.extend({ isAttribute: true }, opts);
+  return makeComputedAttribute(type, opts);
 };
 
 // belongsTo: One-to-one relationship between two models
 RESTless.belongsTo = function(type, opts) {
-  opts = $.extend({ type: type, belongsTo:true, isRelationship:true }, opts);
-  return RESTless._Attribute.create(opts);
+  var defaultRecord = function() {
+    return get(Ember.lookup, type).create();
+  };
+  opts = $.extend({ isRelationship: true, belongsTo: true, defaultValue: defaultRecord }, opts);
+  return makeComputedAttribute(type, opts);
 };
 
 // hasMany: One-to-many & many-to-many relationships
 RESTless.hasMany = function(type, opts) {
-  opts = $.extend({ type: type, hasMany:true, isRelationship:true }, opts);
-  return RESTless._Attribute.create(opts);
+  var defaultArray = function() {
+    return RESTless.RecordArray.createWithContent({type: type});
+  };
+  opts = $.extend({ isRelationship: true, hasMany: true, defaultValue: defaultArray }, opts);
+  return makeComputedAttribute(type, opts);
 };

--- a/src/read_only_model.js
+++ b/src/read_only_model.js
@@ -5,16 +5,11 @@
  * Helps improve performance when write functionality is not needed.
  */
 RESTless.ReadOnlyModel = RESTless.Model.extend({
-  /* 
-   * init: for read-only models, we don't need to _addPropertyObservers 
-   */
-  init: function() {
-    this._initRelationships();
-  },
   /*
    * Remove functionality associated with writing data
    */
   serialize: null,
   saveRecord: null,
-  deleteRecord: null
+  deleteRecord: null,
+  didDefineProperty: null
 });

--- a/tests/index.html
+++ b/tests/index.html
@@ -25,6 +25,7 @@
   <script src="setup.js"></script>
 
   <!-- Tests -->
+  <script src="tests/model.js"></script>
   <script src="tests/client.js"></script>
   <script src="tests/adapter.js"></script>
   <script src="tests/rest_adapter.js"></script>

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -16,3 +16,14 @@ App.Person = RL.Model.extend({
   name: RL.attr('string'),
   role: RL.attr('number')
 });
+
+App.Comment = RL.Model.extend({
+  text: RL.attr('string'),
+  post: RL.belongsTo('App.Post'),
+  author: RL.belongsTo('App.Person'),
+  likes: RL.hasMany('App.Like')
+});
+
+App.Like = RL.Model.extend({
+  username: RL.attr('string')
+});

--- a/tests/tests/model.js
+++ b/tests/tests/model.js
@@ -1,0 +1,93 @@
+var get = Ember.get, set = Ember.set;
+
+module('Model');
+
+test('no longer new once a primary key is assigned', function() {
+  var post = App.Post.create();
+
+  ok( post.get('isNew'), 'new models are new' );
+  post.set('id', 1);
+  ok( !post.get('isNew'), 'models with a primary key are not new' );
+});
+
+
+test('becomes dirty when changing a value', function() {
+  var post = App.Post.create();
+
+  ok( !post.get('isDirty'), 'new models are not dirty' );
+  post.set('title', 'Hello ember!');
+  ok( post.get('isDirty'), 'changed models are dirty' );
+});
+
+
+test('becomes dirty when a relationship becomes dirty', function() {
+  var postGroup = App.PostGroup.load({
+    id: 1,
+    featured: [ { id: 1, title: 'hello' } ]
+  });
+
+  ok( !postGroup.get('isDirty'), 'freshly loaded model is not dirty' );
+
+  postGroup.get('featured').objectAt(0).set('title', 'world');
+
+  ok( postGroup.get('isDirty'), 'dirtying a relationship dirties the parent' );
+});
+
+
+test('attributes can have default values', function() {
+  var model = RL.Model.extend({
+    role: RL.attr('string', { defaultValue: 'user' }),
+    position: RL.attr('number', { defaultValue: 1 }),
+  });
+  var record = model.create({ position: 2 });
+
+  equal( record.get('role'), 'user', 'defaultValue was applied when no value' );
+  equal( record.get('position'), 2, 'defaultValue was not set when value exists' );
+});
+
+
+test('attributes can have a default value functions', function() {
+  var valueFunction = sinon.spy(function() { return new Date(); }),
+      model = RL.Model.extend({ createdAt: RL.attr('date', { defaultValue: valueFunction }) }),
+      record = model.create();
+
+  var createdAt = record.get('createdAt');
+
+  ok( createdAt, 'defaultValue function used when no value');
+  equal( record.get('createdAt'), createdAt, "repeated calls return same value");
+  ok( valueFunction.calledOnce, "function only called once");
+});
+
+
+test('attributes and relationships provided on create are not overwritten', function() {
+  var post = App.Post.create({ title: 'A title' }),
+      comment = App.Comment.create({ post: post, text: 'Some comment' });
+
+  equal( comment.get('post'), post, 'relationship provided on init is same object' );
+  equal( comment.get('post.title'), 'A title', 'related object not changed on init' );
+});
+
+
+test('loading raw representation', function() {
+  var comment = App.Comment.load({
+    id: 1,
+    text: 'This looks awesome!',
+    post: {
+      id: 10,
+      title: 'A new data library'
+    },
+    likes: [
+      { id: 122, username: 'gdub22' },
+      { id: 123, username: 'nixme'  }
+    ]
+  });
+
+  equal( comment.get('id'), 1, 'loads model data' );
+  equal( comment.get('post.id'), 10, 'belongsTo data' );
+  equal( comment.get('likes.firstObject.id'), 122, 'hasMany data' );
+
+  ok( comment.get('isLoaded'),       'model is loaded' );
+  ok( !comment.get('isNew'),         'model is not new' );
+  ok( comment.get('likes.isLoaded'), 'hasMany child is loaded' );
+  ok( comment.get('post.isLoaded'),  'belongsTo is loaded' );
+});


### PR DESCRIPTION
As discussed in #9...

Store attributes in a private data field. RESTless.{attr,belongsTo,hasMany} now generate computed properties similar to ember-data.

Observers for dirty-state tracking are now added at class definition time via `didDefineProperty` instead of at every instance initialization. Improves model instantiation and collection loading performance.

Adds:
- Supports default values. Use `defaultValue` option when declaring an attribute. Supply a value or function.
- Class-level `fields` property returns options for every attribute and relationship in an Ember.Map. `attributeMap` has been removed.

Fixes:
- Related records passed to `create` were being overwritten by `_initRelationships`. Relationships are now initialized lazily using the `defaultValue` mechanism. Also improves performance.
