### PR TITLE
Add paramater support to RESTAdapter findByKey

### DIFF
--- a/dist/ember-restless.js
+++ b/dist/ember-restless.js
@@ -501,11 +501,7 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
     }
 
     var request = $.ajax(params);
-    // Store a reference to the active request and destroy it when finished
     model.set('currentRequest', request);
-    request.always(function() {
-      model.set('currentRequest', null);
-    });
     return request;
   },
 

--- a/src/adapters/rest_adapter.js
+++ b/src/adapters/rest_adapter.js
@@ -66,11 +66,7 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
     }
 
     var request = $.ajax(params);
-    // Store a reference to the active request and destroy it when finished
     model.set('currentRequest', request);
-    request.always(function() {
-      model.set('currentRequest', null);
-    });
     return request;
   },
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,7 +1,7 @@
 App = Ember.Application.create();
 
 App.Post = RL.Model.extend({
-  slug: RL.attr('number'),
+  slug: RL.attr('string'),
   title: RL.attr('string'),
   body: RL.attr('string'),
   tags: RL.hasMany('App.Tag'),
@@ -18,6 +18,7 @@ App.PostGroup = RL.Model.extend({
 });
 
 App.Person = RL.Model.extend({
+  slug: RL.attr('string'),
   name: RL.attr('string'),
   role: RL.attr('number')
 });

--- a/tests/tests/rest_adapter.js
+++ b/tests/tests/rest_adapter.js
@@ -48,3 +48,13 @@ test('creates valid path for multi-word model classes', function() {
       resourceName = get(App.PostGroup, 'resourceName');
   equal( adapter.resourcePath(resourceName), 'post_groups', 'resource path is valid' );
 });
+
+asyncTest('can optionally add query params to a findByKey request', 1, function() {
+  var person = App.Person.find({ id: 1, some_param: 'test' });
+  person.get('currentRequest').always(function() {
+    var urlParts = this.url.split('/');
+    var path = urlParts[urlParts.length-1];
+    equal( path, '1?some_param=test', 'findByKey with parameters requests expected url' );
+    start();
+  });
+});


### PR DESCRIPTION
Needed support for passing parameters through findbyKey() in the REST adapter.

The API is

``` javascript
Article.find({ id: 1, raw_body: true})
```

It then yanks out the primaryKey and passes sends up a request like:

```
GET /articles/1?raw_body=true
```

Thoughts?
