### PR TITLE
Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "ember-restless",
+  "version": "0.4.0",
+  "author": "Garth Poitras",
+  "main": "dist/ember-restless.js",
+  "ignore": [
+    "CHANGELOG.md",
+    "README.md",
+    "tests",
+    ".travis.yml",
+    "package.json",
+    "Gruntfile.js"
+  ]
+}


### PR DESCRIPTION
Not sure if you use Bower for front-end dependency management, but here's a starting point for the bower.json file.

You'll need to add a git tag for 'v0.4.0' (and tags for future releases), can't do that through the PR.

I'll take care of registering the repo with Bower once merged.
