### PR TITLE
Dirtying a readOnly relationship does not dirty parent

### DIFF
--- a/dist/ember-restless+extras.js
+++ b/dist/ember-restless+extras.js
@@ -3,7 +3,7 @@
  * A lightweight data persistence library for Ember.js
  *
  * version: 0.4.0
- * last modifed: 2013-08-08
+ * last modifed: 2013-08-18
  *
  * Garth Poitras <garth22@gmail.com>
  * Copyright (c) 2013 Endless, Inc.
@@ -968,7 +968,7 @@ RESTless.Model = Ember.Object.extend( RESTless.State, Ember.Copyable, {
     if (value instanceof Ember.Descriptor) {
       var meta = value.meta();
 
-      if (meta.isRelationship) {
+      if (meta.isRelationship && !meta.readOnly) {
         // If a relationship's property becomes dirty, need to mark owner as dirty.
         Ember.addObserver(proto, key + '.isDirty', null, '_onRelationshipChange');
       }

--- a/dist/ember-restless.js
+++ b/dist/ember-restless.js
@@ -3,7 +3,7 @@
  * A lightweight data persistence library for Ember.js
  *
  * version: 0.4.0
- * last modifed: 2013-08-08
+ * last modifed: 2013-08-18
  *
  * Garth Poitras <garth22@gmail.com>
  * Copyright (c) 2013 Endless, Inc.
@@ -968,7 +968,7 @@ RESTless.Model = Ember.Object.extend( RESTless.State, Ember.Copyable, {
     if (value instanceof Ember.Descriptor) {
       var meta = value.meta();
 
-      if (meta.isRelationship) {
+      if (meta.isRelationship && !meta.readOnly) {
         // If a relationship's property becomes dirty, need to mark owner as dirty.
         Ember.addObserver(proto, key + '.isDirty', null, '_onRelationshipChange');
       }

--- a/src/model.js
+++ b/src/model.js
@@ -34,7 +34,7 @@ RESTless.Model = Ember.Object.extend( RESTless.State, Ember.Copyable, {
     if (value instanceof Ember.Descriptor) {
       var meta = value.meta();
 
-      if (meta.isRelationship) {
+      if (meta.isRelationship && !meta.readOnly) {
         // If a relationship's property becomes dirty, need to mark owner as dirty.
         Ember.addObserver(proto, key + '.isDirty', null, '_onRelationshipChange');
       }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -14,7 +14,7 @@ App.Tag = RL.Model.extend({
 
 App.PostGroup = RL.Model.extend({
   featured: RL.hasMany('App.Post'),
-  popular: RL.hasMany('App.Post')
+  popular: RL.hasMany('App.Post', { readOnly: true })
 });
 
 App.Person = RL.Model.extend({

--- a/tests/tests/model.js
+++ b/tests/tests/model.js
@@ -71,6 +71,18 @@ test('becomes dirty when a nested relationship becomes dirty', function() {
   ok( postGroup.get('isDirty'), 'dirtying a nested relationship dirties the root object' );
 });
 
+test('does not become dirty when a readOnly nested relationship becomes dirty', function() {
+  var postGroup = App.PostGroup.load({
+    id: 3,
+    popular: [ { id: 2, title: 'world', tags: [ { name: 'tag1' }, { name: 'tag2' } ] } ]
+  });
+
+  ok( !postGroup.get('isDirty'), 'freshly loaded model is not dirty' );
+
+  postGroup.get('popular.firstObject').get('tags.firstObject').set('name', 'tagB');
+
+  ok( !postGroup.get('isDirty'), 'dirtying a readOnly nested relationship did not dirty parent' );
+});
 
 test('attributes can have default values', function() {
   var model = RL.Model.extend({


### PR DESCRIPTION
Basically matches the check at https://github.com/endlessinc/ember-restless/blob/master/src/attribute.js#L47 for regular attributes.

`readOnly` relationships aren't serialized, so changes to them shouldn't dirty the parent.
