### PR TITLE
Deserializing a null belongsTo doesn't create an empty model

### DIFF
--- a/dist/ember-restless+extras.js
+++ b/dist/ember-restless+extras.js
@@ -3,7 +3,7 @@
  * A lightweight data persistence library for Ember.js
  *
  * version: 0.4.0
- * last modifed: 2013-08-08
+ * last modifed: 2013-08-18
  *
  * Garth Poitras <garth22@gmail.com>
  * Copyright (c) 2013 Endless, Inc.
@@ -184,7 +184,7 @@ RESTless.JSONSerializer = RESTless.Serializer.extend({
       resource.set(attrName, hasManyArr);
     } 
     // If property is a belongsTo relationship, deserialze that model
-    else if (field.belongsTo && klass) {
+    else if (field.belongsTo && klass && value) {
       var belongsToModel = klass.create({ isNew: false }).deserialize(value);
       belongsToModel.onLoaded();
       resource.set(attrName, belongsToModel);

--- a/dist/ember-restless.js
+++ b/dist/ember-restless.js
@@ -3,7 +3,7 @@
  * A lightweight data persistence library for Ember.js
  *
  * version: 0.4.0
- * last modifed: 2013-08-08
+ * last modifed: 2013-08-18
  *
  * Garth Poitras <garth22@gmail.com>
  * Copyright (c) 2013 Endless, Inc.
@@ -184,7 +184,7 @@ RESTless.JSONSerializer = RESTless.Serializer.extend({
       resource.set(attrName, hasManyArr);
     } 
     // If property is a belongsTo relationship, deserialze that model
-    else if (field.belongsTo && klass) {
+    else if (field.belongsTo && klass && value) {
       var belongsToModel = klass.create({ isNew: false }).deserialize(value);
       belongsToModel.onLoaded();
       resource.set(attrName, belongsToModel);

--- a/src/serializers/json_serializer.js
+++ b/src/serializers/json_serializer.js
@@ -53,7 +53,7 @@ RESTless.JSONSerializer = RESTless.Serializer.extend({
       resource.set(attrName, hasManyArr);
     } 
     // If property is a belongsTo relationship, deserialze that model
-    else if (field.belongsTo && klass) {
+    else if (field.belongsTo && klass && value) {
       var belongsToModel = klass.create({ isNew: false }).deserialize(value);
       belongsToModel.onLoaded();
       resource.set(attrName, belongsToModel);

--- a/tests/tests/json_serializer.js
+++ b/tests/tests/json_serializer.js
@@ -44,3 +44,15 @@ test('resource key lookups', function() {
   equal(serialzer.attributeNameForKey(post, 'title'), 'title', 'key correct');
   equal(serialzer.attributeNameForKey(post, 'created_at'), 'createdAt', 'key correct');
 });
+
+test('null belongsTo relationship values do not create empty models', function() {
+  var serialzer = RL.JSONSerializer.create(),
+      comment = App.Comment.create(),
+      testJson = { comment: { id: 1, text: 'hello', post: null } };
+
+  comment.deserialize(testJson);
+
+  equal( 'hello', comment.get('text') );
+  equal( null ,   comment.get('post') );
+  equal( null ,   comment.get('author') );
+});


### PR DESCRIPTION
Somewhat similar to 1d3bbb0cbb9824088f7e411d4ca402ef6ec3a561, deserializing a `null` shouldn't create an empty model object.

I could see this being a tad bit controversial, but IMO, a `null` for an embedded `belongsTo` implies the lack of a foreign key or link, thus it should remain blank when the deserialized model is re-serialized.
