### PR TITLE
Fix bug with root path that causes ember query-params support to break.

### DIFF
--- a/src/adapters/rest_adapter.js
+++ b/src/adapters/rest_adapter.js
@@ -51,7 +51,7 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
         ns = this.get('namespace'),
         rootReset = ns && ns.charAt(0) === '/';
 
-    a.href = url ? url : '';
+    a.href = url ? url : '/';
     if(ns) {
       a.pathname = rootReset ? ns : (a.pathname + ns);
     }


### PR DESCRIPTION
The rootPath property is built from the current url. When there are query params it would cause a malformed resource URL to be generated. e.g. http://emberjs.com/api/v1?page=1/articles.json
