### PR TITLE
added a hook that allows the model to modify ajax request params

### DIFF
--- a/src/adapters/rest_adapter.js
+++ b/src/adapters/rest_adapter.js
@@ -90,6 +90,8 @@ RESTless.RESTAdapter = RESTless.Adapter.extend({
         params.data = serializer.prepareData(params.data);
       }
 
+      params = model.prepareRequest(params);
+
       params.success = function(data, textStatus, jqXHR) {
         Ember.run(null, resolve, data);
       };

--- a/src/main/model.js
+++ b/src/main/model.js
@@ -328,5 +328,15 @@ RESTless.Model.reopenClass({
     var array = RESTless.RecordArray.createWithContent().deserializeMany(this.toString(), data);
     array.onLoaded();
     return array;
+  },
+
+  /**
+    Override this method to make changes to any requests made on behalf of this model
+    @method prepareRequest
+    @param {Object} [params] ajax params
+    @return {Object} [params] ajax params
+   */
+  prepareRequest: function(params){
+    return params;
   }
 });


### PR DESCRIPTION
This commit should have no functional change but allow users of this awesome library to make modifications to ajax requests when needed. 

There are a few cases where I've needed to modify ajax requests made on behalf of some of my models to satisfy some weird api requirements. This is a simple patch that gives each model full control over the ajax request sent on its behalf. 

