### PR TITLE
Enable nonembeddable in save record

### DIFF
--- a/dist/ember-restless.js
+++ b/dist/ember-restless.js
@@ -1545,7 +1545,7 @@
       @example '{ 'X-API-KEY' : 'abc1234' }'
       */
     headers: null,
-    
+
     /**
       If an API requires paramters to be set on every request,
       e.g. an api key, you can add a hash of defaults.
@@ -1574,7 +1574,7 @@
     rootPath: Ember.computed('host', 'namespace', function() {
       var rootPath = this.get('host') || '/';
       var namespace = this.get('namespace');
-      
+
       if (namespace) {
         if (rootPath.slice(-1) === '/') {
           rootPath = rootPath.slice(0, -1);
@@ -1644,7 +1644,7 @@
       var serializer = this.serializer;
       var headers = this.get('headers');
       var defaultData = this.get('defaultData');
-      
+
       params = params || {};
       params.type = params.type || 'GET';
       params.dataType = serializer.dataType;
@@ -1694,7 +1694,7 @@
       @param {RESTless.Model} record record to be saved
       @return {Ember.RSVP.Promise}
      */
-    saveRecord: function(record) {
+    saveRecord: function(record, options) {
       var isNew = record.get('isNew'), ajaxPromise;
       //If an existing model isn't dirty, no need to save.
       if(!isNew && !record.get('isDirty')) {
@@ -1705,7 +1705,7 @@
 
       record.set('isSaving', true);
       ajaxPromise = this.request({
-        params: { type: isNew ? 'POST' : 'PUT', data: record.serialize() },
+        params: { type: isNew ? 'POST' : 'PUT', data: record.serialize(options) },
         model: record
       });
 

--- a/dist/ember-restless.js
+++ b/dist/ember-restless.js
@@ -1692,6 +1692,7 @@
       Saves a record. POSTs a new record, or PUTs an updated record to REST API
       @method saveRecord
       @param {RESTless.Model} record record to be saved
+      @param {Object} [options] additional serialization options
       @return {Ember.RSVP.Promise}
      */
     saveRecord: function(record, options) {

--- a/src/adapters/rest-adapter.js
+++ b/src/adapters/rest-adapter.js
@@ -196,6 +196,7 @@ var RESTAdapter = Adapter.extend({
     Saves a record. POSTs a new record, or PUTs an updated record to REST API
     @method saveRecord
     @param {RESTless.Model} record record to be saved
+    @param {Object} [options] additional serialization options
     @return {Ember.RSVP.Promise}
    */
   saveRecord: function(record, options) {

--- a/src/adapters/rest-adapter.js
+++ b/src/adapters/rest-adapter.js
@@ -49,7 +49,7 @@ var RESTAdapter = Adapter.extend({
     @example '{ 'X-API-KEY' : 'abc1234' }'
     */
   headers: null,
-  
+
   /**
     If an API requires paramters to be set on every request,
     e.g. an api key, you can add a hash of defaults.
@@ -78,7 +78,7 @@ var RESTAdapter = Adapter.extend({
   rootPath: Ember.computed('host', 'namespace', function() {
     var rootPath = this.get('host') || '/';
     var namespace = this.get('namespace');
-    
+
     if (namespace) {
       if (rootPath.slice(-1) === '/') {
         rootPath = rootPath.slice(0, -1);
@@ -148,7 +148,7 @@ var RESTAdapter = Adapter.extend({
     var serializer = this.serializer;
     var headers = this.get('headers');
     var defaultData = this.get('defaultData');
-    
+
     params = params || {};
     params.type = params.type || 'GET';
     params.dataType = serializer.dataType;
@@ -198,7 +198,7 @@ var RESTAdapter = Adapter.extend({
     @param {RESTless.Model} record record to be saved
     @return {Ember.RSVP.Promise}
    */
-  saveRecord: function(record) {
+  saveRecord: function(record, options) {
     var isNew = record.get('isNew'), ajaxPromise;
     //If an existing model isn't dirty, no need to save.
     if(!isNew && !record.get('isDirty')) {
@@ -209,7 +209,7 @@ var RESTAdapter = Adapter.extend({
 
     record.set('isSaving', true);
     ajaxPromise = this.request({
-      params: { type: isNew ? 'POST' : 'PUT', data: record.serialize() },
+      params: { type: isNew ? 'POST' : 'PUT', data: record.serialize(options) },
       model: record
     });
 


### PR DESCRIPTION
When saving records we need to be able to specify the data without embedding it in a root element. This is known, as the option exists in the `JSONSerializer`, however it has not been available when using the `RESTAdapter`. 

This passes any options directly on to the serializer. If the serializer doesn't take options, it will be ignored. Should any options ever be needed for the `saveRecord` method then they can be safely merged into this same parameter. 

As no tests currently existed for `saveRecord` there were none to be modified or easily added. Let me know if there's anything else you need.
