### PR TITLE
Ember 2.x/FastBoot compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "ember": ">= 1.0.0"
   },
   "devDependencies": {
-    "ember": "2.0.0",
+    "ember": ">= 2.0.0",
     "pretender": "~0.6.0",
     "qunit": "~1.18.0"
   }

--- a/src/client.js
+++ b/src/client.js
@@ -31,7 +31,20 @@ Ember.Application.initializer({
     application.addObserver('Client', application, function() {
       RESTless.set('client', this.Client);
     });
-    RESTless.__container__ = application.__container__;
+
+    var container = application.__container__;
+    RESTless.lookupFactory = function() {
+      return container.lookupFactory.apply(container, arguments);
+    };
+  }
+});
+
+Ember.Application.instanceInitializer({
+  name: 'RESTless.Client',
+  initialize: function(applicationInstance) {
+    RESTless.lookupFactory = function() {
+      return applicationInstance._lookupFactory.apply(applicationInstance, arguments);
+    };
   }
 });
 

--- a/src/model/record-array.js
+++ b/src/model/record-array.js
@@ -103,8 +103,19 @@ RecordArray.reopenClass({
     @method create
     @returns RESTless.RecordArray
    */
-  create: function() {
-    var arr = this._super.apply(this, arguments);
+  create: function(options) {
+    // If no content was provided, default to an empty array.
+    options = options || {};
+    if (!options.content) {
+      options.content = Ember.A();
+    }
+
+    // Properly apply rest args to super's create()
+    var restArgs = Array.prototype.slice.call(arguments, 1);
+    var args = [options].concat(restArgs);
+
+    var arr = this._super.apply(this, args);
+
     // override State defaults not implemented or applicable to arrays
     arr.setProperties({ _isReady: true, isNew: false });
     return arr;
@@ -114,12 +125,8 @@ RecordArray.reopenClass({
     @method createWithContent
     @returns RESTless.RecordArray
    */
-  createWithContent: function(options) {
-    options = options || {};
-    if (!options.content) {
-      options.content = Ember.A();
-    }
-    return this.create(options);
+  createWithContent: function() {
+    return this.create.apply(this, arguments);
   }
 });
 

--- a/src/serializers/serializer.js
+++ b/src/serializers/serializer.js
@@ -39,7 +39,7 @@ var Serializer = Ember.Object.extend({
       }
 
       // Container support
-      return RESTless.__container__.lookupFactory('model:' + type);
+      return RESTless.lookupFactory('model:' + type);
     }
     return type;
   },


### PR DESCRIPTION
- In Ember 2.x, ArrayProxy must have its content property set before it is mutated. This commit changes the semantics of `RecordArray.create()` to be the same as `RecordArray.createWithContent()`
- Correctly grabs the private container off the application instance (thus making ember-restless FastBoot-compatible)